### PR TITLE
Add update-omz target and fix submodule leftover migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,27 @@
 #
 # Makefile to copy dotfiles into place
 #
-.PHONY: fetch copy diff diff-long install update clean unlink bootstrap-omz
+.PHONY: fetch copy diff diff-long install update clean unlink bootstrap-omz update-omz
 
-update: fetch install
+update: fetch install update-omz
 
-# Clone oh-my-zsh custom plugins/themes if they're missing. Once cloned,
-# `omz update` (run by oh-my-zsh on its own schedule) keeps them current.
+# Clone oh-my-zsh custom plugins/themes if missing, and re-clone any leftover
+# submodule checkouts (identified by .git being a file rather than a directory).
 bootstrap-omz:
+	@for dir in zsh_custom/themes/powerlevel10k zsh_custom/plugins/zsh-syntax-highlighting; do \
+		[ -f "$$dir/.git" ] && echo "$$dir: leftover submodule checkout, re-cloning..." && rm -rf "$$dir" || true; \
+	done
 	@[ -d zsh_custom/themes/powerlevel10k ] || \
 		git clone --depth=1 https://github.com/romkatv/powerlevel10k.git \
 			zsh_custom/themes/powerlevel10k
 	@[ -d zsh_custom/plugins/zsh-syntax-highlighting ] || \
 		git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting.git \
 			zsh_custom/plugins/zsh-syntax-highlighting
+
+# Pull latest commits in the oh-my-zsh-managed clones.
+update-omz:
+	@git -C zsh_custom/themes/powerlevel10k pull --ff-only
+	@git -C zsh_custom/plugins/zsh-syntax-highlighting pull --ff-only
 
 fetch:
 	@git pull

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To keep local changes separate from the tracked dotfiles, use `~/.zshrc.local`. 
 You can clone the repository wherever you want. (I like to keep it in `~/Projects/dotfiles`, with `~/dotfiles` as a symlink.) The Makefile will pull in the latest version and copy the files to your home folder.
 
 ```sh
-git clone https://github.com/neybar/dotfiles.git && cd dotfiles && git submodule update --init --recursive && make install
+git clone https://github.com/neybar/dotfiles.git && cd dotfiles && make install
 ```
 
 To update, `cd` into your local `dotfiles` repository and then:
@@ -45,7 +45,10 @@ make update
 - **`make diff`** — Preview which files would be changed (quick summary)
 - **`make diff-long`** — Show detailed diffs of all changes before applying them
 - **`make copy`** — Copy dotfiles to home directory without running installers
-- **`make install`** — Run `make copy`, update vim plugins, and configure git
+- **`make install`** — Run `make copy`, clone oh-my-zsh plugins/themes, update vim plugins, and configure git
+- **`make update`** — Pull latest dotfiles and run `make install`, then pull latest oh-my-zsh plugins/themes
+- **`make update-omz`** — Pull latest commits in the powerlevel10k and zsh-syntax-highlighting clones
+- **`make bootstrap-omz`** — Clone oh-my-zsh plugins/themes if missing (run automatically by `make install`)
 
 If you're making local changes and just want to copy files into place:
 ```sh


### PR DESCRIPTION
## Summary

- Adds `update-omz` target that runs `git pull --ff-only` in the powerlevel10k and zsh-syntax-highlighting clones, wired into `make update` so plugins stay current on existing machines
- `bootstrap-omz` now detects leftover submodule checkouts (`.git` file vs directory) and re-clones them automatically, handling migration on machines that still have the old submodule working trees after #2
- Updates README: removes stale `git submodule update --init --recursive` from the install command, documents the new `update-omz` and `bootstrap-omz` targets

## Test plan

- [ ] `make update` on a machine with existing clones pulls latest in both plugins
- [ ] `make install` on a machine where the dirs are leftover submodule checkouts re-clones them cleanly
- [ ] `make install` on a fresh checkout clones both as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)